### PR TITLE
fix: web will also throw it wheb native throws an error

### DIFF
--- a/packages/react-native/src/integrations/bridge.ts
+++ b/packages/react-native/src/integrations/bridge.ts
@@ -23,15 +23,24 @@ export const handleBridge = async ({
   webview,
   eventId,
 }: HandleBridgeArgs) => {
-  const response = await bridge[method]?.(...(args ?? []));
+  try {
+    const response = await bridge[method]?.(...(args ?? []));
 
-  webview.injectJavaScript(`
+    webview.injectJavaScript(`
     window.nativeEmitter.emit('${method}-${eventId}',${JSON.stringify(
       response,
     )});
   
     true;
   `);
+  } catch (error) {
+    console.error(error);
+    webview.injectJavaScript(`
+    window.nativeEmitter.emit('${method}-${eventId}', {}, true);
+
+    true;
+  `);
+  }
 };
 
 export const INTEGRATIONS_SCRIPTS_BRIDGE = (bridgeNames: string[]) => `

--- a/packages/web/src/error.ts
+++ b/packages/web/src/error.ts
@@ -5,9 +5,9 @@ export class MethodNotFoundError extends Error {
   }
 }
 
-export class NativeBridgeError extends Error {
+export class NativeMethodError extends Error {
   constructor(methodName: string) {
     super(`An error occurred in the native bridge: ${methodName}`);
-    this.name = "NativeBridgeError";
+    this.name = "NativeMethodError";
   }
 }

--- a/packages/web/src/error.ts
+++ b/packages/web/src/error.ts
@@ -4,3 +4,10 @@ export class MethodNotFoundError extends Error {
     this.name = "MethodNotFoundError";
   }
 }
+
+export class NativeBridgeError extends Error {
+  constructor(methodName: string) {
+    super(`An error occurred in the native bridge: ${methodName}`);
+    this.name = "NativeBridgeError";
+  }
+}

--- a/shared/util/src/createEvents.ts
+++ b/shared/util/src/createEvents.ts
@@ -42,12 +42,25 @@ export const createResolver = (
   method: string,
   eventId: string,
   evaluate: () => void,
+  failHandler: Error | false = false,
 ) => {
-  return new Promise((resolve) => {
-    const unbind = emitter.on(`${method}-${eventId}`, (data) => {
-      unbind();
-      resolve(data);
-    });
+  return new Promise((resolve, reject) => {
+    const unbind = emitter.on(
+      `${method}-${eventId}`,
+      (data, throwOccurred: boolean) => {
+        unbind();
+
+        if (throwOccurred) {
+          if (failHandler instanceof Error) {
+            reject(failHandler);
+          } else {
+            resolve(void 0);
+          }
+        } else {
+          resolve(data);
+        }
+      },
+    );
     evaluate();
   });
 };


### PR DESCRIPTION
## Test Usage

```ts
const nativeMethod = linkNativeMethod<AppBridge>({
  throwOnError: true,
});

try {
  await nativeMethod.openInAppBrowser(123);
}
catch(e) {
  if(e instanceof NativeMethodError) {
     console.log("native method execution failed");
  }
}
```