### PR TITLE
feat: loose, native methods loose on types and errors

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -34,7 +34,17 @@ export default defineConfig({
           },
           {
             text: "Backward Compatibility",
-            link: "/backward-compatibility",
+            base: "/backward-compatibility",
+            items: [
+              {
+                text: "New Method",
+                link: "/new-method",
+              },
+              {
+                text: "Deprecated Method",
+                link: "/deprecated-method",
+              },
+            ],
           },
         ],
       },

--- a/docs/backward-compatibility/deprecated-method.md
+++ b/docs/backward-compatibility/deprecated-method.md
@@ -1,0 +1,58 @@
+# Backward Compatibility for Deprecated Method
+
+Since a WebView is web-based, it can always be updated to the latest version upon deployment. In contrast, rolling out updates for a React Native app can take time.
+
+You can't always keep `nativeMethod` up-to-date on the web, as the app gets updated and deprecated methods may still exist.
+
+For example, there might be methods that have been deleted or methods whose arguments have changed.
+
+As a result, even if your web is up to date, you should be able to handle older versions of your native app.
+
+## React Native Part
+
+### Bridge Versioning
+When declaring methods in the bridge, it's helpful to create a method that includes versioning. Whenever there are changes in methods, increasing the version number makes it easier to handle from the web side.
+
+```ts
+export const appBridge = bridge({
+  // A bridge scenario that existed in the past. Assume this method existed in a previous version.
+  // async getBridgeVersion() {
+  //   return 1;
+  // },
+  // async getOldVersionMessage() {
+  //   return "I'm from native old version" as const;
+  // },
+
+  async getBridgeVersion() {
+    return 2;
+  },
+  async getMessage() {
+    return "I'm from native" as const;
+  },
+});
+```
+
+## Web  Part
+
+### loose
+
+Using the `loose` keyword in `nativeMethod`, even if there's a `throwOnError` field, no error will occur. It provides minimal type completion without throwing errors for unknown types.
+
+For older versions, simply appending the `.loose` prefix to the previous method is enough.
+
+```ts
+const nativeMethod = linkNativeMethod<AppBridge>({
+  throwOnError: true,
+});
+
+const version = await nativeMethod.getBridgeVersion();
+if (version >= 2) {
+  const message = await nativeMethod.getMessage();
+  console.log(message);
+} else {
+  // Support for old native methods with `loose`
+  const oldVersionMessage =
+  await nativeMethod.loose.getOldVersionMessage();
+  console.log(oldVersionMessage);
+}
+```

--- a/docs/backward-compatibility/deprecated-method.md
+++ b/docs/backward-compatibility/deprecated-method.md
@@ -36,9 +36,7 @@ export const appBridge = bridge({
 
 ### loose
 
-Using the `loose` keyword in `nativeMethod`, even if there's a `throwOnError` field, no error will occur. It provides minimal type completion without throwing errors for unknown types.
-
-For older versions, simply appending the `.loose` prefix to the previous method is enough.
+Using the `loose` keyword in `nativeMethod`, It provides minimal type completion without throwing errors for unknown types.
 
 ```ts
 const nativeMethod = linkNativeMethod<AppBridge>({

--- a/docs/backward-compatibility/new-method.md
+++ b/docs/backward-compatibility/new-method.md
@@ -1,6 +1,6 @@
-# Backward Compatibility
+# Backward Compatibility for New Method
 
-Since a WebView is web-based, it can always be kept up-to-date upon deployment. In contrast, rolling out a React Native app can take time.
+Since a WebView is web-based, it can always be updated to the latest version upon deployment. In contrast, rolling out updates for a React Native app can take time.
 
 When a new method is added in React Native, it can be invoked from the web.
 
@@ -79,7 +79,7 @@ const nativeMethod = linkNativeMethod<AppBridge>({
 
 ## React Native Part
 
-For example, it's configured as follows. You can handle this through the `createWebview` fallback field.
+For example, it's configured as follows. You can handle this through the `createWebView` fallback field.
 
 ```tsx
 export const appBridge = bridge({

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -16,6 +16,9 @@ import InAppBrowser from "react-native-inappbrowser-reborn";
 import { WebBridge } from "@webview-bridge/example-web";
 
 export const appBridge = bridge({
+  async getBridgeVersion() {
+    return 1;
+  },
   async getMessage() {
     return "I'm from native" as const;
   },

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -16,8 +16,16 @@ import InAppBrowser from "react-native-inappbrowser-reborn";
 import { WebBridge } from "@webview-bridge/example-web";
 
 export const appBridge = bridge({
+  // A bridge scenario that existed in the past. Assume the this method existed in a previous version.
+  // async getBridgeVersion() {
+  //   return 1;
+  // },
+  // async getOldVersionMessage() {
+  //   return "I'm from native old version" as const;
+  // },
+
   async getBridgeVersion() {
-    return 1;
+    return 2;
   },
   async getMessage() {
     return "I'm from native" as const;

--- a/example/web/src/App.tsx
+++ b/example/web/src/App.tsx
@@ -20,9 +20,20 @@ function App() {
   const [message, setMessage] = useState("");
 
   useEffect(() => {
-    nativeMethod.getMessage().then((message) => {
-      setMessage(message);
-    });
+    async function init() {
+      const version = await nativeMethod.getBridgeVersion();
+      if (version >= 2) {
+        const message = await nativeMethod.getMessage();
+        setMessage(message);
+      } else {
+        // Support for old native methods with `loose`
+        const oldVersionMessage =
+          await nativeMethod.loose.getOldVersionMessage();
+        setMessage(oldVersionMessage);
+      }
+    }
+
+    init();
   }, []);
 
   return (
@@ -31,7 +42,9 @@ function App() {
       <h1>{message}</h1>
       <button
         onClick={() => {
-          if (nativeMethod.isNativeMethodAvailable("openInAppBrowser")) {
+          if (
+            nativeMethod.isNativeMethodAvailable("openInAppBrowser") === true
+          ) {
             nativeMethod.openInAppBrowser(
               "https://github.com/gronxb/webview-bridge",
             );

--- a/packages/web/src/linkNativeMethod.ts
+++ b/packages/web/src/linkNativeMethod.ts
@@ -12,8 +12,8 @@ const emitter = createEvents();
 
 export interface LinkNativeMethodOptions<BridgeObject extends Bridge> {
   timeout?: number;
-  throwOnError?: boolean | (keyof BridgeObject)[];
-  onFallback?: (method: keyof BridgeObject) => void;
+  throwOnError?: boolean | (keyof BridgeObject)[] | string[];
+  onFallback?: (method: string) => void;
 }
 
 const createNativeMethod =
@@ -76,11 +76,13 @@ export const linkNativeMethod = <BridgeObject extends Bridge>(
 
   const target = bridgeMethods.reduce(
     (acc, method) => {
-      const throwOnError = willMethodThrowOnError(method);
-
       return {
         ...acc,
-        [method]: createNativeMethod(method, timeoutMs, throwOnError),
+        [method]: createNativeMethod(
+          method,
+          timeoutMs,
+          willMethodThrowOnError(method),
+        ),
       };
     },
     {
@@ -106,7 +108,11 @@ export const linkNativeMethod = <BridgeObject extends Bridge>(
       ) {
         return target[method];
       }
-      return createNativeMethod(method, timeoutMs, false);
+      return createNativeMethod(
+        method,
+        timeoutMs,
+        willMethodThrowOnError(method),
+      );
     },
   });
 
@@ -125,7 +131,7 @@ export const linkNativeMethod = <BridgeObject extends Bridge>(
           },
         }),
       );
-      onFallback?.(method as keyof BridgeObject);
+      onFallback?.(method);
 
       if (willMethodThrowOnError(method)) {
         return () => Promise.reject(new MethodNotFoundError(method));

--- a/packages/web/src/linkNativeMethod.ts
+++ b/packages/web/src/linkNativeMethod.ts
@@ -40,7 +40,7 @@ const createNativeMethod =
         },
         throwOnError && new NativeMethodError(method),
       ),
-      timeout(timeoutMs),
+      timeout(timeoutMs, throwOnError),
     ]);
   };
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -3,7 +3,15 @@ export type AsyncFunction = (...args: any[]) => Promise<any>;
 
 export type Bridge = Record<string, AsyncFunction>;
 
-export type WithAvailable<T> = {
+export type NativeMethod<T> = {
   isWebViewBridgeAvailable: boolean;
   isNativeMethodAvailable(method: keyof T): boolean;
+  isNativeMethodAvailable(method: string): boolean;
+  loose: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [K in keyof T]: (...args: any[]) => any;
+  } & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: (...args: any[]) => any;
+  };
 } & T;

--- a/shared/util/src/timeout.ts
+++ b/shared/util/src/timeout.ts
@@ -1,7 +1,11 @@
-export const timeout = (ms: number) => {
-  return new Promise((_, reject) => {
+export const timeout = (ms: number, throwOnError: boolean = true) => {
+  return new Promise((resolve, reject) => {
     setTimeout(() => {
-      reject(new Error("Timeout"));
+      if (throwOnError) {
+        reject(new Error("Timeout"));
+      } else {
+        resolve(void 0);
+      }
     }, ms);
   });
 };


### PR DESCRIPTION
## React Native Part

### Bridge Versioning
When declaring methods in the bridge, it's helpful to create a method that includes versioning. Whenever there are changes in methods, increasing the version number makes it easier to handle from the web side.

```ts
export const appBridge = bridge({
  // A bridge scenario that existed in the past. Assume this method existed in a previous version.
  // async getBridgeVersion() {
  //   return 1;
  // },
  // async getOldVersionMessage() {
  //   return "I'm from native old version" as const;
  // },

  async getBridgeVersion() {
    return 2;
  },
  async getMessage() {
    return "I'm from native" as const;
  },
});
```

## Web  Part

### loose

Using the `loose` keyword in `nativeMethod`, It provides minimal type completion without throwing errors for unknown types.

```ts
const nativeMethod = linkNativeMethod<AppBridge>({
  throwOnError: true,
});

const version = await nativeMethod.getBridgeVersion();
if (version >= 2) {
  const message = await nativeMethod.getMessage();
  console.log(message);
} else {
  // Support for old native methods with `loose`
  const oldVersionMessage =
  await nativeMethod.loose.getOldVersionMessage();
  console.log(oldVersionMessage);
}
```
