### PR TITLE
fix: resolve import error in some environment

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,9 +15,9 @@
     "dist",
     "package.json"
   ],
-  "main": "/dist/commonjs/index.cjs",
-  "module": "/dist/module/index.mjs",
-  "types": "/dist/typescript/packages/web/src/index.d.ts",
+  "main": "dist/commonjs/index.cjs",
+  "module": "dist/module/index.mjs",
+  "types": "dist/typescript/packages/web/src/index.d.ts",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
I found the reason why it cannot be found in the some environments.

paths of the main, module, type in the /web/package.json have an additional slash( '/' ) in front of correct path.

so I remove them.