### PR TITLE
(PoC) feat: type safe `eventBridge` and `postMessage`

### DIFF
--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -5,6 +5,7 @@
  * @format
  */
 
+import { z } from "zod";
 import React, { useState } from "react";
 import { Button, Text, SafeAreaView } from "react-native";
 import {
@@ -23,7 +24,6 @@ export const appBridge = bridge({
   // async getOldVersionMessage() {
   //   return "I'm from native old version" as const;
   // },
-
   async getBridgeVersion() {
     return 2;
   },
@@ -37,11 +37,17 @@ export const appBridge = bridge({
   },
 });
 
-export const { WebView, linkWebMethod } = createWebView({
+export const { WebView, linkWebMethod, postMessage } = createWebView({
   bridge: appBridge,
   debug: true,
   fallback: (method) => {
     console.warn(`Method '${method}' not found in native`);
+  },
+
+  validatePostMessage: {
+    openModal: z.object({
+      isOpen: z.boolean(),
+    }),
   },
 });
 

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -56,8 +56,6 @@ export const { WebView, linkWebMethod, postMessage } = createWebView({
   },
 });
 
-postMessage("openModal", { isOpen: true });
-
 const WebMethod = linkWebMethod<WebBridge>();
 
 function App(): JSX.Element {
@@ -87,6 +85,10 @@ function App(): JSX.Element {
     WebMethod.current.throw(true).catch((e) => console.error("(test)", e));
   };
 
+  const handlePostMessage = () => {
+    postMessage("openModal", { isOpen: true });
+  };
+
   return (
     <SafeAreaView style={{ height: "100%" }}>
       <WebView
@@ -96,6 +98,8 @@ function App(): JSX.Element {
         }}
         style={{ height: "100%", flex: 1, width: "100%" }}
       />
+      <Button onPress={handlePostMessage} title="postMessage (openModal)" />
+
       <Button onPress={handleWebAlert} title="Web Alert" />
       {value > 0 && (
         <Text style={{ alignSelf: "center" }}>

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -10,8 +10,10 @@ import React, { useState } from "react";
 import { Button, Text, SafeAreaView } from "react-native";
 import {
   bridge,
+  eventBridge,
   createWebView,
   type BridgeWebView,
+  bind,
 } from "@webview-bridge/react-native";
 import InAppBrowser from "react-native-inappbrowser-reborn";
 import { WebBridge } from "@webview-bridge/example-web";
@@ -37,19 +39,24 @@ export const appBridge = bridge({
   },
 });
 
+export const appEvent = eventBridge({
+  openModal: z.object({
+    isOpen: z.boolean(),
+  }),
+  openModal2: z.object({
+    test: z.boolean(),
+  }),
+});
+
 export const { WebView, linkWebMethod, postMessage } = createWebView({
-  bridge: appBridge,
+  bridge: bind([appBridge, appEvent]),
   debug: true,
   fallback: (method) => {
     console.warn(`Method '${method}' not found in native`);
   },
-
-  validatePostMessage: {
-    openModal: z.object({
-      isOpen: z.boolean(),
-    }),
-  },
 });
+
+postMessage("openModal", { test: true });
 
 const WebMethod = linkWebMethod<WebBridge>();
 

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -18,7 +18,7 @@ import {
 import InAppBrowser from "react-native-inappbrowser-reborn";
 import { WebBridge } from "@webview-bridge/example-web";
 
-export const appBridge = bridge({
+export const appMethod = bridge({
   // A bridge scenario that existed in the past. Assume the this method existed in a previous version.
   // async getBridgeVersion() {
   //   return 1;
@@ -49,7 +49,7 @@ export const appEvent = eventBridge({
 });
 
 export const { WebView, linkWebMethod, postMessage } = createWebView({
-  bridge: bind([appBridge, appEvent]),
+  bridge: bind([appMethod, appEvent]),
   debug: true,
   fallback: (method) => {
     console.warn(`Method '${method}' not found in native`);

--- a/example/react-native/App.tsx
+++ b/example/react-native/App.tsx
@@ -56,7 +56,7 @@ export const { WebView, linkWebMethod, postMessage } = createWebView({
   },
 });
 
-postMessage("openModal", { test: true });
+postMessage("openModal", { isOpen: true });
 
 const WebMethod = linkWebMethod<WebBridge>();
 

--- a/example/react-native/package.json
+++ b/example/react-native/package.json
@@ -15,7 +15,8 @@
     "react": "18.2.0",
     "react-native": "0.72.5",
     "react-native-inappbrowser-reborn": "^3.7.0",
-    "react-native-webview": "^13.6.2"
+    "react-native-webview": "^13.6.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/example/react-native/src/bridge.ts
+++ b/example/react-native/src/bridge.ts
@@ -1,3 +1,4 @@
-import { appBridge } from "../App";
+import { appEvent, appMethod } from "../App";
 
-export type AppBridge = typeof appBridge;
+export type AppMethod = typeof appMethod;
+export type AppEvent = typeof appEvent;

--- a/example/web/package.json
+++ b/example/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@webview-bridge/web": "workspace:^",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/example/web/src/App.tsx
+++ b/example/web/src/App.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import "./App.css";
 import {
   linkNativeMethod,
-  linkNativeEvent,
+  linkNativeEventListener,
   registerWebMethod,
 } from "@webview-bridge/web";
 import type { AppMethod, AppEvent } from "@webview-bridge/example-native";
@@ -37,14 +37,14 @@ const nativeMethod = linkNativeMethod<AppMethod>({
   throwOnError: true,
 });
 
-const emitter = linkNativeEvent<AppEvent>();
+const listener = linkNativeEventListener<AppEvent>();
 
 function useNativeEventListener<K extends keyof Omit<AppEvent, "__signature">>(
   eventName: K,
   cb: (data: z.infer<Omit<AppEvent, "__signature">[K]>) => void,
 ) {
   useEffect(() => {
-    return emitter.on(eventName, cb);
+    return listener.on(eventName, cb);
   }, []);
 }
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,7 +26,8 @@
     "@types/react": "^18.2.25",
     "react": "^18.2.0",
     "react-native-webview": "^13.6.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/react-native/src/createWebView.tsx
+++ b/packages/react-native/src/createWebView.tsx
@@ -1,4 +1,4 @@
-import { createEvents, createRandomId } from "@webview-bridge/util";
+import { createEvents } from "@webview-bridge/util";
 import {
   createRef,
   forwardRef,
@@ -203,11 +203,10 @@ export const createWebView = <
       if (!_webviewRef.current) {
         throw new Error("postMessage is not ready");
       }
-      const eventId = createRandomId();
       return _webviewRef.current.injectJavaScript(`
-        window.webEmitter.emit('${String(
-          eventName,
-        )}', '${eventId}', ${JSON.stringify(data)});
+        window.eventEmitter.emit('${String(eventName)}', ${JSON.stringify(
+          data,
+        )});
 
         true;
         `);

--- a/packages/react-native/src/createWebView.tsx
+++ b/packages/react-native/src/createWebView.tsx
@@ -216,11 +216,9 @@ export const createWebView = <
         current: WebMethod<T>;
       };
     },
-    postMessage(
-      eventName: Exclude<keyof EventBridgeObject, "__signature">,
-      data: z.infer<
-        EventBridgeObject[Exclude<keyof EventBridgeObject, "__signature">]
-      >,
+    postMessage<T extends Exclude<keyof EventBridgeObject, "__signature">>(
+      eventName: T,
+      data: z.infer<EventBridgeObject[T]>,
     ) {
       if (!_webviewRef.current) {
         throw new Error("postMessage is not ready");

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./createWebView";
+export * from "./integrations/bind";
 export * from "./integrations/bridge";
+export * from "./integrations/eventBridge";
 export * from "./types/bridge";
 export * from "./types/webview";

--- a/packages/react-native/src/integrations/bind.ts
+++ b/packages/react-native/src/integrations/bind.ts
@@ -1,0 +1,22 @@
+import { BridgeSignature } from "../types/bridge";
+
+export const bind = <
+  T extends { __signature: BridgeSignature },
+  U extends { __signature: BridgeSignature },
+>(
+  bridges: [T, U],
+) => {
+  const methodBridge = (bridges.find(
+    (item) => item?.__signature === "methodBridge",
+  ) ?? { __signature: "methodBridge" }) as T;
+
+  const eventBridge =
+    bridges.find((item) => item?.__signature === "eventBridge") ??
+    ({ __signature: "eventBridge" } as U);
+
+  return [methodBridge, eventBridge] as T extends {
+    __signature: "methodBridge";
+  }
+    ? [T, U]
+    : [U, T];
+};

--- a/packages/react-native/src/integrations/bridge.ts
+++ b/packages/react-native/src/integrations/bridge.ts
@@ -46,6 +46,6 @@ export const handleBridge = async ({
   }
 };
 
-export const INTEGRATIONS_SCRIPTS_BRIDGE = (bridgeNames: string[]) => `
+export const INTEGRATIONS_SCRIPTS_METHOD_BRIDGE = (bridgeNames: string[]) => `
     window.__bridgeMethods__ = [${bridgeNames.join(", ")}];
 `;

--- a/packages/react-native/src/integrations/bridge.ts
+++ b/packages/react-native/src/integrations/bridge.ts
@@ -1,17 +1,20 @@
 import WebView from "react-native-webview";
 
-import type { Bridge } from "../types/bridge";
+import type { MethodBridge } from "../types/bridge";
 
-export const bridge = <BridgeObject extends Bridge>(
+export const bridge = <BridgeObject extends Omit<MethodBridge, "__signature">>(
   procedures: BridgeObject,
-): BridgeObject => {
-  return procedures;
+): MethodBridge<BridgeObject> => {
+  return {
+    ...procedures,
+    __signature: "methodBridge",
+  } as MethodBridge<BridgeObject>;
 };
 
-type HandleBridgeArgs<ArgType = unknown> = {
-  bridge: Bridge;
+type HandleBridgeArgs = {
+  bridge: MethodBridge;
   method: string;
-  args?: ArgType[];
+  args?: unknown[];
   webview: WebView;
   eventId: string;
 };

--- a/packages/react-native/src/integrations/eventBridge.ts
+++ b/packages/react-native/src/integrations/eventBridge.ts
@@ -1,0 +1,12 @@
+import { EventBridge } from "../types/bridge";
+
+export const eventBridge = <
+  EventBridgeObject extends Omit<EventBridge, "__signature">,
+>(
+  procedures: EventBridgeObject,
+): EventBridge<EventBridgeObject> => {
+  return {
+    ...procedures,
+    __signature: "eventBridge",
+  } as EventBridge<EventBridgeObject>;
+};

--- a/packages/react-native/src/integrations/handleRegisterWebMethod.ts
+++ b/packages/react-native/src/integrations/handleRegisterWebMethod.ts
@@ -7,7 +7,7 @@ import {
 import WebView from "react-native-webview";
 
 import { WebMethodError } from "../error";
-import { Bridge } from "../types/bridge";
+import { MethodBridge } from "../types/bridge";
 
 export const handleRegisterWebMethod = (
   emitter: EventEmitter,
@@ -42,5 +42,5 @@ export const handleRegisterWebMethod = (
     };
 
     return acc;
-  }, {} as Bridge);
+  }, {} as MethodBridge);
 };

--- a/packages/react-native/src/types/bridge.ts
+++ b/packages/react-native/src/types/bridge.ts
@@ -1,4 +1,24 @@
+import { z } from "zod";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AsyncFunction = (...args: any[]) => Promise<any>;
 
-export type Bridge = Record<string, AsyncFunction>;
+export type InferMethodBridge<T> = {
+  [K in keyof T]: T[K] extends AsyncFunction ? T[K] : never;
+};
+
+export type InferEventBridge<T> = {
+  [K in keyof T]: T[K] extends z.AnyZodObject ? T[K] : never;
+};
+
+export type MethodBridge<T = Record<string, AsyncFunction>> =
+  InferMethodBridge<T> & {
+    __signature: "methodBridge";
+  };
+
+export type EventBridge<T = Record<string, z.AnyZodObject>> =
+  InferEventBridge<T> & {
+    __signature: "eventBridge";
+  };
+
+export type BridgeSignature = "methodBridge" | "eventBridge";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "test:type": "tsc --noEmit"
   },
   "devDependencies": {
-    "esbuild": "^0.19.4"
+    "esbuild": "^0.19.4",
+    "zod": "^3.22.4"
   }
 }

--- a/packages/web/src/global.d.ts
+++ b/packages/web/src/global.d.ts
@@ -7,6 +7,7 @@ declare global {
     __bridgeMethods__?: string[];
     nativeEmitter?: EventEmitter<DefaultEvents>;
     webEmitter?: EventEmitter<DefaultEvents>;
+    eventEmitter?: EventEmitter<DefaultEvents>;
     ReactNativeWebView: {
       postMessage: (data: string) => void;
     };

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./error";
+export * from "./linkNativeEvent";
 export * from "./linkNativeMethod";
 export * from "./registerWebMethod";
 export type * from "./types";

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./error";
-export * from "./linkNativeEvent";
+export * from "./linkNativeEventListener";
 export * from "./linkNativeMethod";
 export * from "./registerWebMethod";
 export type * from "./types";

--- a/packages/web/src/linkNativeEvent.ts
+++ b/packages/web/src/linkNativeEvent.ts
@@ -1,0 +1,20 @@
+import { createEvents } from "@webview-bridge/util";
+import { z } from "zod";
+
+import { EventBridge } from "./types";
+
+export const linkNativeEvent = <
+  EventBridgeObject extends EventBridge<EventBridgeObject>,
+>() => {
+  const emitter = createEvents();
+
+  window.eventEmitter = emitter;
+  return {
+    on: <K extends keyof Omit<EventBridgeObject, "__signature">>(
+      event: K,
+      callback: (data: z.infer<EventBridgeObject[K]>) => void,
+    ) => {
+      return emitter.on(event as string, callback);
+    },
+  };
+};

--- a/packages/web/src/linkNativeEventListener.ts
+++ b/packages/web/src/linkNativeEventListener.ts
@@ -4,17 +4,21 @@ import { z } from "zod";
 import { EventBridge } from "./types";
 
 export const linkNativeEventListener = <
-  EventBridgeObject extends EventBridge<EventBridgeObject>,
+  EventBridgeObject extends EventBridge<EventBridgeObject> = {
+    __signature: "eventBridge";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  },
 >() => {
   const emitter = createEvents();
 
   window.eventEmitter = emitter;
   return {
     on: <K extends keyof Omit<EventBridgeObject, "__signature">>(
-      event: K,
+      eventName: K,
       callback: (data: z.infer<EventBridgeObject[K]>) => void,
     ) => {
-      return emitter.on(event as string, callback);
+      return emitter.on(eventName as string, callback);
     },
   };
 };

--- a/packages/web/src/linkNativeEventListener.ts
+++ b/packages/web/src/linkNativeEventListener.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { EventBridge } from "./types";
 
-export const linkNativeEvent = <
+export const linkNativeEventListener = <
   EventBridgeObject extends EventBridge<EventBridgeObject>,
 >() => {
   const emitter = createEvents();

--- a/packages/web/src/registerWebMethod.ts
+++ b/packages/web/src/registerWebMethod.ts
@@ -1,8 +1,8 @@
 import { createEvents } from "@webview-bridge/util";
 
-import type { Bridge } from "./types";
+import type { AsyncObject } from "./types";
 
-export const registerWebMethod = <BridgeObject extends Bridge>(
+export const registerWebMethod = <BridgeObject extends AsyncObject>(
   bridge: BridgeObject,
 ): BridgeObject => {
   if (!window.ReactNativeWebView) {

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AsyncFunction = (...args: any[]) => Promise<any>;
 
-export type Bridge = Record<string, AsyncFunction>;
+export type AsyncObject = Record<string, AsyncFunction>;
+
+export type MethodBridge<T extends object> = {
+  [key in keyof T]: key extends "__signature" ? "methodBridge" : AsyncFunction;
+};
 
 export type NativeMethod<T> = {
   isWebViewBridgeAvailable: boolean;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -1,10 +1,18 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AsyncFunction = (...args: any[]) => Promise<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type NotAsyncFunction = (...args: any[]) => any;
 
 export type AsyncObject = Record<string, AsyncFunction>;
 
 export type MethodBridge<T extends object> = {
   [key in keyof T]: key extends "__signature" ? "methodBridge" : AsyncFunction;
+};
+
+export type EventBridge<T extends object> = {
+  [key in keyof T]: key extends "__signature"
+    ? "eventBridge"
+    : Zod.AnyZodObject;
 };
 
 export type NativeMethod<T> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@types/react':
         specifier: ^18.2.15
@@ -187,6 +190,9 @@ importers:
       esbuild:
         specifier: ^0.19.4
         version: 0.19.4
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
 
   shared/util: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-native-webview:
         specifier: ^13.6.2
         version: 13.6.2(react-native@0.72.5)(react@18.2.0)
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -175,6 +178,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
 
   packages/web:
     devDependencies:
@@ -8973,3 +8979,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}


### PR DESCRIPTION
You can send events to the web in one way.

## Simple Usage

### Native Part
```tsx
export const appMethod = bridge({
  // .. native method
});

// here
export const appEvent = eventBridge({
  openModal: z.object({
    isOpen: z.boolean(),
  }),
  openModal2: z.object({
    test: z.boolean(),
  }),
});

// here
export type AppEvent = typeof appEvent;

export const { postMessage } = createWebView({
  // register event bridge  
  bridge: bind([appMethod, appEvent]),

  // ... default options
});

// using
postMessage("openModal", { isOpen: true });
```

### Web Part
```tsx
const listener = linkNativeEventListener<AppEvent>();

listener.on("openModal", (data) => {
  console.log(`receive ${data}`);
});
```

Suggestions Type:
![image](https://github.com/gronxb/webview-bridge/assets/41789633/fae0a855-6f46-4c58-9c83-d769e43b5d7a)
![image](https://github.com/gronxb/webview-bridge/assets/41789633/ef69447a-5cb0-4680-a3eb-7e54a32b7fdd)
