### PR TITLE
chore: polyfill useSyncExternalStore

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.25",
+    "@types/use-sync-external-store": "^0.0.6",
     "react": "^18.2.0",
     "react-native-webview": "^13.6.2",
     "typescript": "^5.2.2"
@@ -31,5 +32,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native-webview": "*"
+  },
+  "dependencies": {
+    "use-sync-external-store": "^1.2.0"
   }
 }

--- a/packages/react-native/src/useBridge.ts
+++ b/packages/react-native/src/useBridge.ts
@@ -1,5 +1,5 @@
 import type { Bridge, BridgeStore, ExtractStore } from "@webview-bridge/types";
-import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 export function useBridge<T extends Bridge>(
   store: BridgeStore<T>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,10 +272,17 @@ importers:
         version: 18.2.0(react@18.2.0)
 
   packages/react-native:
+    dependencies:
+      use-sync-external-store:
+        specifier: ^1.2.0
+        version: 1.2.0(react@18.2.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.25
         version: 18.2.25
+      '@types/use-sync-external-store':
+        specifier: ^0.0.6
+        version: 0.0.6
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -3314,6 +3321,10 @@ packages:
 
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+
+  /@types/use-sync-external-store@0.0.6:
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+    dev: true
 
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}


### PR DESCRIPTION
Compatible with react 18 and below to use useSyncExternalStore