### PR TITLE
feat: initialBridge mock

### DIFF
--- a/example/shared-state-integration-react/react/src/App.tsx
+++ b/example/shared-state-integration-react/react/src/App.tsx
@@ -63,10 +63,9 @@ function App() {
       <h2>This is WebView</h2>
       <button
         onClick={() => {
-          console.log(bridge);
-          // if (bridge.isNativeMethodAvailable("openInAppBrowser") === true) {
-          bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
-          // }
+          if (bridge.isNativeMethodAvailable("openInAppBrowser") === true) {
+            bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
+          }
         }}
       >
         open InAppBrowser

--- a/example/shared-state-integration-react/react/src/App.tsx
+++ b/example/shared-state-integration-react/react/src/App.tsx
@@ -6,6 +6,24 @@ import type { AppBridge } from "@webview-bridge-example-shared-state-integration
 
 const bridge = linkBridge<AppBridge>({
   throwOnError: true,
+  initialBridge: {
+    count: 10,
+    data: {
+      text: "Test",
+    },
+    increase: async () => {
+      alert("not support increase");
+    },
+    openInAppBrowser: async (url) => {
+      alert("not support openInAppBrowser: " + url);
+    },
+    setDataText: async (text) => {
+      alert("not support setDataText: " + text);
+    },
+    getMessage: async () => {
+      return "mocking message";
+    },
+  },
   onReady: () => {
     console.log("bridge is ready");
   },
@@ -43,12 +61,12 @@ function App() {
         {`isWebViewBridgeAvailable: ${String(bridge.isWebViewBridgeAvailable)}`}
       </div>
       <h2>This is WebView</h2>
-
       <button
         onClick={() => {
-          if (bridge.isNativeMethodAvailable("openInAppBrowser") === true) {
-            bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
-          }
+          console.log(bridge);
+          // if (bridge.isNativeMethodAvailable("openInAppBrowser") === true) {
+          bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
+          // }
         }}
       >
         open InAppBrowser

--- a/packages/web/src/internal/bridgeInstance.ts
+++ b/packages/web/src/internal/bridgeInstance.ts
@@ -54,9 +54,7 @@ export class BridgeInstance<
 
   public isNativeMethodAvailable(methodName: string) {
     return (
-      typeof methodName === "string" &&
-      Boolean(window.ReactNativeWebView) &&
-      this._bridgeMethods.includes(methodName)
+      typeof methodName === "string" && this._bridgeMethods.includes(methodName)
     );
   }
 

--- a/packages/web/src/internal/bridgeInstance.ts
+++ b/packages/web/src/internal/bridgeInstance.ts
@@ -29,7 +29,7 @@ export class BridgeInstance<
     private _options: LinkBridgeOptions<T, V>,
 
     private _emitter: DefaultEmitter,
-    private _bridgeMethods: string[],
+    private _bridgeMethods: string[] = [],
     public _nativeInitialState: PrimitiveObject,
   ) {
     this._hydrate(_bridgeMethods, _nativeInitialState);

--- a/packages/web/src/internal/linkBridgeStore.ts
+++ b/packages/web/src/internal/linkBridgeStore.ts
@@ -18,7 +18,6 @@ export const linkBridgeStore = <
 >(
   emitter: DefaultEmitter,
   initialState: Partial<T> = {},
-  nativeInitialState: Partial<T> = {},
 ): Omit<T, "setState"> => {
   const getState = () => state;
 
@@ -41,7 +40,7 @@ export const linkBridgeStore = <
     setState(data);
   });
 
-  let state: T = { ...initialState, ...nativeInitialState } as T;
+  let state: T = { ...initialState } as T;
 
   const listeners = new Set<(newState: T, prevState: T) => void>();
 

--- a/packages/web/src/internal/mockStore.ts
+++ b/packages/web/src/internal/mockStore.ts
@@ -1,12 +1,14 @@
 import { PrimitiveObject } from "@webview-bridge/types";
 
-export const mockStore = (initialState: PrimitiveObject = {}) =>
-  ({
-    state: initialState,
-    getState() {
-      return this.state;
-    },
-    subscribe() {
-      return () => {};
-    },
-  }) as const;
+export const mockStore = (initialState: PrimitiveObject = {}) => {
+  const state = initialState;
+
+  const getState = () => state;
+
+  const subscribe = () => () => {};
+
+  return {
+    getState,
+    subscribe,
+  };
+};

--- a/packages/web/src/internal/mockStore.ts
+++ b/packages/web/src/internal/mockStore.ts
@@ -1,9 +1,12 @@
-export const mockStore = () => ({
-  state: {},
-  getState() {
-    return this.state;
-  },
-  subscribe() {
-    return () => {};
-  },
-});
+import { PrimitiveObject } from "@webview-bridge/types";
+
+export const mockStore = (initialState: PrimitiveObject = {}) =>
+  ({
+    state: initialState,
+    getState() {
+      return this.state;
+    },
+    subscribe() {
+      return () => {};
+    },
+  }) as const;

--- a/packages/web/src/linkBridge.ts
+++ b/packages/web/src/linkBridge.ts
@@ -17,6 +17,7 @@ export interface LinkBridgeOptions<
   T extends BridgeStore<T extends Bridge ? T : any>,
   V extends ParserSchema<any>,
 > {
+  initialBridge?: Partial<ExtractStore<T>>;
   timeout?: number;
   throwOnError?: boolean | (keyof ExtractStore<T>)[] | string[];
   onFallback?: (methodName: string, args: unknown[]) => void;
@@ -45,7 +46,10 @@ export const linkBridge = <
 ): LinkBridge<ExcludePrimitive<ExtractStore<T>>, Omit<T, "setState">, V> => {
   if (typeof window === "undefined") {
     return {
-      store: mockStore() as unknown as Omit<T, "setState">,
+      store: mockStore(options?.initialBridge) as unknown as Omit<
+        T,
+        "setState"
+      >,
     } as LinkBridge<ExcludePrimitive<ExtractStore<T>>, Omit<T, "setState">, V>;
   }
 


### PR DESCRIPTION
https://github.com/gronxb/webview-bridge/issues/54#issuecomment-2219301712

It is possible to configure `initialBridge` to operate in a non-React Native environment.
Prioritize applying the bridge of the React Native WebView, and if it is unavailable, apply the `initialBridge`.
Therefore, if `initialBridge` is configured, `bridge.isWebViewBridgeAvailable` should be true even in environments that are not React Native.