### PR TITLE
fix: Use tsup config file to preserve jsx transpiling strategy

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -28,7 +28,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --target es5",
+    "build": "tsup --config ./tsup.config.ts",
     "test:type": "tsc --noEmit",
     "lint": "biome check"
   },

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  target: "es5",
+  esbuildOptions(options) {
+    options.jsx = "automatic";
+  },
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --target es5",
+    "build": "tsup --config ./tsup.config.ts",
     "test:type": "tsc --noEmit",
     "lint": "biome check"
   },

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  target: "es5",
+  esbuildOptions(options) {
+    options.jsx = "automatic";
+  },
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsup src/index.ts --dts",
+    "build": "tsup --config ./tsup.config.ts",
     "test:type": "tsc --noEmit",
     "lint": "biome check"
   },

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --target es5",
+    "build": "tsup --config ./tsup.config.ts",
     "test:type": "tsc --noEmit",
     "lint": "biome check"
   },

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  target: "es5",
+  esbuildOptions(options) {
+    options.jsx = "automatic";
+  },
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --target es5",
+    "build": "tsup --config ./tsup.config.ts",
     "test:type": "tsc --noEmit",
     "lint": "biome check"
   },

--- a/packages/web/tsup.config.ts
+++ b/packages/web/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  target: "es5",
+  esbuildOptions(options) {
+    options.jsx = "automatic";
+  },
+});


### PR DESCRIPTION
- Due to https://github.com/egoist/tsup/issues/792, tsup>=7.20 ignore jsx transpiling options in tsconfig.
- This can cause problems like #96.
- Can be solved by overriding the esbuild setting in the tsup config file.
  - https://github.com/egoist/tsup/issues/792#issuecomment-2443773071